### PR TITLE
Production image assets require image helper

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -15,7 +15,7 @@
 
 body {
   font-family: sans-serif;
-  background-image: url('pizza.png');
+  background-image: image-url('pizza.png');
   margin: 0 auto;
   width: 600px;
 }


### PR DESCRIPTION
In production if you refer to assets in the asset pipeline you have to
use SCSS or SASS and use the image-url helper.
