### PR TITLE
Adjust pizza logo height and h1 font size.

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -21,7 +21,7 @@ body {
 
 h1 {
   font-family: 'Lucida Casual', 'Comic Sans MS';
-  font-size: 100px;
+  font-size: 88px;
   text-align: center;
 }
 
@@ -40,7 +40,7 @@ li {
 }
 
 .pizza-logo {
-  min-height: 139px;
+  height: 132px;
 }
 
 footer {


### PR DESCRIPTION
- Change the pizza logo height to be a height instead of min-height, this fixes
  the stuttering on Firefox
- Bump the h1 font-size down so it does not break to two lines on Firefox

Fixes #12.

![pizza](http://ihatedominospizza.files.wordpress.com/2011/04/pizza-tracker.jpg)
