### PR TITLE
Do not error if secrets.yml is not present.

### DIFF
--- a/config/initializers/load_secrets.rb
+++ b/config/initializers/load_secrets.rb
@@ -1,7 +1,15 @@
 PizzaTime::Application.configure do
   # Note: Hashie is a gem dependency
   if ENV['RAILS_ENV'] == 'development'
-    config.secrets = Hashie::Mash.new(YAML.load_file(Rails.root.join('config', 'secrets.yml'))[Rails.env.to_s])
+    secrets_file = Rails.root.join('config', 'secrets.yml')
+
+    config.secrets = if File.exist?(secrets_file)
+      Hashie::Mash.new(YAML.load_file(secrets_file)[Rails.env.to_s])
+    else
+      $stderr.puts "We were unable to locate the required API keys. Please enter them in `config/secrets.yml`."
+      Hashie::Mash.new
+    end
+
     ENV['meetup_key'] = config.secrets.meetup_key
   end
 end


### PR DESCRIPTION
I could not start the server without adding a `config/secrets.yml`.

This change logs a helpful message to the console, and continues.
